### PR TITLE
Fix: Moonshot Sell SWAP mint parsing was wrong

### DIFF
--- a/parse/parse_moonshot.go
+++ b/parse/parse_moonshot.go
@@ -104,6 +104,7 @@ func (p *Parser) parseMoonshotTradeInstruction(instruction solana.CompiledInstru
 	if tradeType == TradeTypeBuy {
 		instructionWithMint.Instruction.Data.TokenAmount = tokenBalanceChangesAbs
 	} else {
+		instructionWithMint.Mint = p.txInfo.Message.AccountKeys[instruction.Accounts[6]]
 		instructionWithMint.Instruction.Data.CollateralAmount = tokenBalanceChangesAbs
 	}
 


### PR DESCRIPTION
Here's the output for a sell swap : 
```
  "Timestamp": "0001-01-01T00:00:00Z",
  "TokenInMint": "So11111111111111111111111111111111111111112",
  "TokenInAmount": 59948049312246101,
  "TokenInDecimals": 9,
  "TokenOutMint": "So11111111111111111111111111111111111111112",
  "TokenOutAmount": 1711486459,
  "TokenOutDecimals": 9
```

Amounts are good but mints are identicals.

This PR try to fix this issue.